### PR TITLE
feat(web): add result detail route and profile settings page

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/web/src/app/(app)/results/[id]/page.tsx
+++ b/apps/web/src/app/(app)/results/[id]/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import type { AnalysisResult, Finding, Severity } from "@debugiq/shared-types";
+import { getResult } from "@/lib/api/results";
+import { ApiError } from "@/lib/api/client";
+import { SeverityBadge, Badge, categoryLabel } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
+
+export default function ResultDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const id = params.id ?? "";
+
+  const [result, setResult] = useState<AnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setLoading(false);
+      setNotFound(true);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    getResult(id)
+      .then((data) => {
+        setResult(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true);
+        } else {
+          setError(
+            err instanceof ApiError ? err.detail : "Failed to load result.",
+          );
+        }
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+        <p className="text-lg font-semibold text-white">Result not found</p>
+        <p className="text-sm text-muted">
+          This analysis doesn&apos;t exist or belongs to another account.
+        </p>
+        <Button variant="secondary" onClick={() => router.back()}>
+          ← Back
+        </Button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+        <p className="text-lg font-semibold text-white">Error loading result</p>
+        <p className="text-sm text-red-400">{error}</p>
+        <Button variant="secondary" onClick={() => router.back()}>
+          ← Back
+        </Button>
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const severitySummary = countSeverities(result);
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* Breadcrumb */}
+      <div>
+        <Link
+          href="/dashboard"
+          className="text-sm text-muted transition-colors hover:text-white"
+        >
+          ← Dashboard
+        </Link>
+      </div>
+
+      {/* Header */}
+      <div>
+        <h1 className="text-xl font-semibold text-white">Result Detail</h1>
+        <p className="mt-0.5 font-mono text-xs text-muted">{result.result_id}</p>
+      </div>
+
+      {/* Metadata card */}
+      <div className="rounded-lg border border-white/5 bg-surface-1 p-5">
+        <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted">
+          Metadata
+        </h2>
+        <dl className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-3">
+          <MetaItem label="Analyzed">{formatDate(result.analyzed_at)}</MetaItem>
+          <MetaItem label="Language">
+            <Badge variant={result.language === "python" ? "blue" : "purple"}>
+              {result.language}
+            </Badge>
+          </MetaItem>
+          <MetaItem label="Mode">
+            <Badge variant={result.mode === "learn" ? "green" : "default"}>
+              {result.mode}
+            </Badge>
+          </MetaItem>
+          <MetaItem label="Model">
+            <span className="font-mono text-xs text-white">
+              {result.model_used}
+            </span>
+          </MetaItem>
+          <MetaItem label="Duration">
+            {result.duration_ms != null ? `${result.duration_ms} ms` : "—"}
+          </MetaItem>
+          {result.demo_mode && (
+            <MetaItem label="Demo">
+              <Badge variant="default">demo</Badge>
+            </MetaItem>
+          )}
+        </dl>
+      </div>
+
+      {/* Severity summary */}
+      {result.findings_count > 0 && (
+        <div className="rounded-lg border border-white/5 bg-surface-1 p-5">
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted">
+            Severity Summary
+          </h2>
+          <div className="flex flex-wrap gap-3">
+            {(
+              ["critical", "high", "medium", "low", "info"] as Severity[]
+            ).map((s) =>
+              severitySummary[s] > 0 ? (
+                <div key={s} className="flex items-center gap-1.5">
+                  <SeverityBadge severity={s} />
+                  <span className="tabular-nums text-sm text-white">
+                    {severitySummary[s]}
+                  </span>
+                </div>
+              ) : null,
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Findings list */}
+      <div>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted">
+          Findings ({result.findings_count})
+        </h2>
+        {result.findings.length === 0 ? (
+          <div className="rounded-lg border border-white/5 bg-surface-1 p-8 text-center text-sm text-muted">
+            No findings for this analysis.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {result.findings.map((f) => (
+              <FindingCard key={f.id} finding={f} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function countSeverities(
+  result: AnalysisResult,
+): Record<Severity, number> {
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  for (const f of result.findings) {
+    counts[f.severity]++;
+  }
+  return counts;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function MetaItem({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-muted">{label}</dt>
+      <dd className="mt-0.5 text-sm text-white">{children}</dd>
+    </div>
+  );
+}
+
+function FindingCard({ finding }: { finding: Finding }) {
+  return (
+    <article className="rounded-lg border border-white/5 bg-surface-1 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-medium text-white">{finding.title}</p>
+          <p className="mt-0.5 text-xs text-muted">
+            Lines {finding.line_start}–{finding.line_end} &middot;{" "}
+            {categoryLabel[finding.category]}
+          </p>
+        </div>
+        <SeverityBadge severity={finding.severity} />
+      </div>
+      <p className="mt-2 text-sm text-muted/80">{finding.description}</p>
+      {(finding.fix_hint ?? finding.explanation) && (
+        <div className="mt-3 rounded border border-white/5 bg-surface-0 px-3 py-2 text-xs text-muted">
+          {finding.fix_hint ?? finding.explanation}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/lib/auth/context";
+import { patchMe } from "@/lib/api/users";
+import { ApiError } from "@/lib/api/client";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+type SaveState = "idle" | "saving" | "success" | "error";
+
+export default function SettingsPage() {
+  const { user, refreshUser } = useAuth();
+  const [displayName, setDisplayName] = useState(user?.display_name ?? "");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaveState("saving");
+    setErrorMsg(null);
+    try {
+      const trimmed = displayName.trim();
+      await patchMe({ display_name: trimmed || undefined });
+      await refreshUser();
+      setSaveState("success");
+      // Auto-clear the success banner after 3 seconds.
+      setTimeout(() => setSaveState((s) => (s === "success" ? "idle" : s)), 3000);
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.detail : "Failed to save changes.";
+      setErrorMsg(msg);
+      setSaveState("error");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-xl font-semibold text-white">Settings</h1>
+        <p className="mt-0.5 text-sm text-muted">
+          Manage your profile and account.
+        </p>
+      </div>
+
+      {/* Profile card */}
+      <div className="max-w-lg rounded-lg border border-white/5 bg-surface-1 p-6">
+        <h2 className="mb-5 text-xs font-semibold uppercase tracking-wider text-muted">
+          Profile
+        </h2>
+
+        <form onSubmit={handleSave} className="flex flex-col gap-4" noValidate>
+          {/* Email — read only */}
+          <div>
+            <p className="mb-1 text-sm font-medium text-white/80">Email</p>
+            <p
+              aria-label="Email address"
+              className="rounded-lg border border-white/5 bg-surface-0 px-3 py-2 text-sm text-muted"
+            >
+              {user?.email ?? "—"}
+            </p>
+          </div>
+
+          {/* Plan — read only */}
+          <div>
+            <p className="mb-1 text-sm font-medium text-white/80">Plan</p>
+            <p
+              aria-label="Current plan"
+              className="rounded-lg border border-white/5 bg-surface-0 px-3 py-2 text-sm capitalize text-muted"
+            >
+              {user?.tier ?? "—"}
+            </p>
+          </div>
+
+          {/* Member since — read only */}
+          {user?.created_at && (
+            <div>
+              <p className="mb-1 text-sm font-medium text-white/80">
+                Member since
+              </p>
+              <p
+                aria-label="Member since"
+                className="rounded-lg border border-white/5 bg-surface-0 px-3 py-2 text-sm text-muted"
+              >
+                {new Date(user.created_at).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </p>
+            </div>
+          )}
+
+          {/* Display name — editable */}
+          <Input
+            label="Display name"
+            type="text"
+            autoComplete="name"
+            value={displayName}
+            onChange={(e) => {
+              setDisplayName(e.target.value);
+              if (saveState !== "idle") setSaveState("idle");
+            }}
+            hint="Shown in the sidebar and dashboard."
+            placeholder="Your name"
+          />
+
+          {/* Feedback banners */}
+          {saveState === "success" && (
+            <div
+              role="status"
+              className="rounded-lg border border-green-700/50 bg-green-900/20 px-4 py-3 text-sm text-green-300"
+            >
+              Profile updated successfully.
+            </div>
+          )}
+          {saveState === "error" && errorMsg && (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-700/50 bg-red-900/20 px-4 py-3 text-sm text-red-300"
+            >
+              {errorMsg}
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            loading={saveState === "saving"}
+            className="w-full sm:w-auto"
+          >
+            Save changes
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/lib/auth/context";
+import { Button } from "@/components/ui/Button";
+
+interface NavItem {
+  href: string;
+  label: string;
+  /** Phase-2 items are visually marked as coming soon. */
+  phase2?: boolean;
+  /** SVG path string for icon */
+  icon: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  {
+    href: "/dashboard",
+    label: "Dashboard",
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l9-9 9 9M4 10v10a1 1 0 001 1h5v-5h4v5h5a1 1 0 001-1V10" />
+      </svg>
+    ),
+  },
+  {
+    href: "/team",
+    label: "Team",
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2h5M12 12a4 4 0 100-8 4 4 0 000 8z" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dojo",
+    label: "Dojo",
+    phase2: true,
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+      </svg>
+    ),
+  },
+  {
+    href: "/billing",
+    label: "Billing",
+    phase2: true,
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+      </svg>
+    ),
+  },
+  {
+    href: "/settings",
+    label: "Settings",
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+  },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+  const { user, logout } = useAuth();
+
+  return (
+    <aside className="flex w-60 flex-col gap-6 border-r border-white/5 bg-surface-1 px-4 py-6">
+      {/* Brand */}
+      <div className="flex items-center gap-2 px-2">
+        <span className="text-lg font-bold tracking-tight text-white">
+          Debug<span className="text-brand-500">IQ</span>
+        </span>
+        <span className="rounded bg-brand-900/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-500">
+          beta
+        </span>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex flex-1 flex-col gap-1">
+        {navItems.map((item) => {
+          const active = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`group flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${
+                active
+                  ? "bg-brand-500/15 text-white"
+                  : "text-muted hover:bg-surface-2 hover:text-white"
+              }`}
+            >
+              <span className="flex items-center gap-2.5">
+                {item.icon}
+                {item.label}
+              </span>
+              {item.phase2 && (
+                <span className="rounded bg-surface-3 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted">
+                  soon
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* User footer */}
+      <div className="flex flex-col gap-3 border-t border-white/5 pt-4">
+        {user && (
+          <div className="px-2">
+            <p className="truncate text-sm font-medium text-white">
+              {user.display_name ?? user.email.split("@")[0]}
+            </p>
+            <p className="truncate text-xs text-muted">{user.email}</p>
+            <span className="mt-1 inline-block rounded bg-brand-900/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-500">
+              {user.tier}
+            </span>
+          </div>
+        )}
+        <Button variant="ghost" size="sm" onClick={logout} className="w-full justify-start px-2">
+          <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+          Sign out
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/results/ResultsTable.tsx
+++ b/apps/web/src/components/results/ResultsTable.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import type { AnalysisResult, Severity } from "@debugiq/shared-types";
+import type { PaginatedResults } from "@debugiq/shared-types";
+import { SeverityBadge, Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
+
+interface ResultsTableProps {
+  data: PaginatedResults<AnalysisResult> | null;
+  loading: boolean;
+  error: string | null;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Returns the highest severity among findings, or null if no findings. */
+function worstSeverity(result: AnalysisResult): Severity | null {
+  const order: Severity[] = ["critical", "high", "medium", "low", "info"];
+  for (const s of order) {
+    if (result.findings.some((f) => f.severity === s)) return s;
+  }
+  return null;
+}
+
+export function ResultsTable({
+  data,
+  loading,
+  error,
+  page,
+  pageSize,
+  onPageChange,
+}: ResultsTableProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-700/50 bg-red-900/20 p-6 text-center text-red-300">
+        <p className="font-medium">Failed to load results</p>
+        <p className="mt-1 text-sm text-red-400/80">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data || data.items.length === 0) {
+    return (
+      <div className="rounded-lg border border-white/5 bg-surface-1 p-12 text-center">
+        <p className="text-muted">No analysis results yet.</p>
+        <p className="mt-1 text-sm text-muted/70">
+          Run an analysis from the VS Code extension to see results here.
+        </p>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(data.total / pageSize);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-white/5">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-white/5 bg-surface-1 text-left text-xs uppercase tracking-wider text-muted">
+              <th className="px-4 py-3">Analyzed</th>
+              <th className="px-4 py-3">Language</th>
+              <th className="px-4 py-3">Mode</th>
+              <th className="px-4 py-3">Findings</th>
+              <th className="px-4 py-3">Worst</th>
+              <th className="px-4 py-3">Model</th>
+              <th className="px-4 py-3">Duration</th>
+              <th className="px-4 py-3 sr-only">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((result) => {
+              const worst = worstSeverity(result);
+              const isOpen = expanded === result.result_id;
+
+              return (
+                <React.Fragment key={result.result_id}>
+                  <tr
+                    className="cursor-pointer border-b border-white/5 transition-colors hover:bg-surface-1"
+                    onClick={() =>
+                      setExpanded(isOpen ? null : result.result_id)
+                    }
+                  >
+                    <td className="px-4 py-3 font-mono text-xs text-muted">
+                      {formatDate(result.analyzed_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge
+                        variant={
+                          result.language === "python" ? "blue" : "purple"
+                        }
+                      >
+                        {result.language}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge
+                        variant={result.mode === "learn" ? "green" : "default"}
+                      >
+                        {result.mode}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 tabular-nums">
+                      {result.findings_count}
+                      {result.demo_mode && (
+                        <span className="ml-1.5 text-xs text-muted">(demo)</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {worst ? (
+                        <SeverityBadge severity={worst} />
+                      ) : (
+                        <span className="text-xs text-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-muted">
+                      {result.model_used}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-muted">
+                      {result.duration_ms != null
+                        ? `${result.duration_ms}ms`
+                        : "—"}
+                    </td>
+                    <td
+                      className="px-4 py-3"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Link
+                        href={`/results/${result.result_id}`}
+                        className="text-xs font-medium text-brand-500 hover:underline"
+                        aria-label={`View details for result ${result.result_id}`}
+                      >
+                        View →
+                      </Link>
+                    </td>
+                  </tr>
+
+                  {/* Expanded findings panel */}
+                  {isOpen && result.findings.length > 0 && (
+                    <tr key={`${result.result_id}-findings`}>
+                      <td colSpan={8} className="bg-surface-0 px-6 py-4">
+                        <div className="flex flex-col gap-2">
+                          <p className="text-xs font-semibold uppercase tracking-wider text-muted">
+                            Findings
+                          </p>
+                          {result.findings.map((f) => (
+                            <div
+                              key={f.id}
+                              className="rounded-lg border border-white/5 bg-surface-1 px-4 py-3"
+                            >
+                              <div className="flex items-start justify-between gap-4">
+                                <div>
+                                  <p className="font-medium text-white">
+                                    {f.title}
+                                  </p>
+                                  <p className="mt-0.5 text-xs text-muted">
+                                    Lines {f.line_start}–{f.line_end} •{" "}
+                                    {f.category}
+                                  </p>
+                                </div>
+                                <SeverityBadge severity={f.severity} />
+                              </div>
+                              {(f.fix_hint || f.explanation) && (
+                                <p className="mt-2 text-xs text-muted/80">
+                                  {f.fix_hint ?? f.explanation}
+                                </p>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-muted">
+          <span>
+            Page {page} of {totalPages} — {data.total} total
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => onPageChange(page - 1)}
+            >
+              ← Prev
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => onPageChange(page + 1)}
+            >
+              Next →
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth/context.tsx
+++ b/apps/web/src/lib/auth/context.tsx
@@ -1,0 +1,164 @@
+"use client";
+/**
+ * apps/web/src/lib/auth/context.tsx
+ *
+ * AuthContext — provides current user state and auth actions (login, register,
+ * logout) to the entire app via React context.
+ *
+ * Session lifecycle:
+ *  1. On mount, reads stored tokens and fetches /v0/users/me to hydrate user.
+ *  2. The API client handles transparent refresh on 401.
+ *  3. The "debugiq:auth:expired" DOM event (fired by client.ts on failed refresh)
+ *     triggers a hard logout here.
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import type { UserResponse } from "@debugiq/shared-types";
+import * as authApi from "@/lib/api/auth";
+import { getMe } from "@/lib/api/users";
+import { setTokens, clearTokens, getTokens } from "@/lib/auth/tokens";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface AuthState {
+  user: UserResponse | null;
+  /** True while we are hydrating from stored tokens on first mount. */
+  loading: boolean;
+  error: string | null;
+}
+
+interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>;
+  register: (
+    email: string,
+    password: string,
+    displayName?: string,
+  ) => Promise<void>;
+  logout: () => Promise<void>;
+  clearError: () => void;
+  /** Re-fetches /v0/users/me and updates the user in context (e.g. after profile edit). */
+  refreshUser: () => Promise<void>;
+}
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    user: null,
+    loading: true,
+    error: null,
+  });
+
+  // Hydrate user from stored tokens on mount.
+  useEffect(() => {
+    const tokens = getTokens();
+    if (!tokens) {
+      setState((s) => ({ ...s, loading: false }));
+      return;
+    }
+    getMe()
+      .then((user) => setState({ user, loading: false, error: null }))
+      .catch(() => {
+        clearTokens();
+        setState({ user: null, loading: false, error: null });
+      });
+  }, []);
+
+  // Listen for hard expiry signals from the API client.
+  useEffect(() => {
+    const handler = () => {
+      clearTokens();
+      setState({ user: null, loading: false, error: null });
+    };
+    window.addEventListener("debugiq:auth:expired", handler);
+    return () => window.removeEventListener("debugiq:auth:expired", handler);
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const tokens = await authApi.login({ email, password });
+      setTokens(tokens);
+      const user = await getMe();
+      setState({ user, loading: false, error: null });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "login_failed";
+      setState((s) => ({ ...s, loading: false, error: msg }));
+      throw err;
+    }
+  }, []);
+
+  const register = useCallback(
+    async (email: string, password: string, displayName?: string) => {
+      setState((s) => ({ ...s, loading: true, error: null }));
+      try {
+        await authApi.register({
+          email,
+          password,
+          display_name: displayName,
+        });
+        // Auto-login after register.
+        const tokens = await authApi.login({ email, password });
+        setTokens(tokens);
+        const user = await getMe();
+        setState({ user, loading: false, error: null });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "register_failed";
+        setState((s) => ({ ...s, loading: false, error: msg }));
+        throw err;
+      }
+    },
+    [],
+  );
+
+  const logout = useCallback(async () => {
+    const tokens = getTokens();
+    try {
+      if (tokens?.refresh_token) {
+        await authApi.logout({ refresh_token: tokens.refresh_token });
+      }
+    } catch {
+      // Best-effort — clear local state regardless.
+    } finally {
+      clearTokens();
+      setState({ user: null, loading: false, error: null });
+    }
+  }, []);
+
+  const clearError = useCallback(() => {
+    setState((s) => ({ ...s, error: null }));
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      const user = await getMe();
+      setState((s) => ({ ...s, user }));
+    } catch {
+      // Best-effort — don't force logout on a profile refresh failure.
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ ...state, login, register, logout, clearError, refreshUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside <AuthProvider>");
+  }
+  return ctx;
+}

--- a/apps/web/src/test/navigation.test.tsx
+++ b/apps/web/src/test/navigation.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Navigation wiring tests.
+ * Covers: Sidebar renders a Settings link; ResultsTable renders per-row View links.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/dashboard"),
+  useParams: vi.fn(() => ({})),
+  useRouter: vi.fn(() => ({ back: vi.fn() })),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-label": ariaLabel,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) =>
+    React.createElement("a", { href, className, "aria-label": ariaLabel }, children),
+}));
+
+vi.mock("@/lib/auth/context", () => ({
+  useAuth: () => ({
+    user: {
+      user_id: "user-1",
+      email: "nav@example.com",
+      display_name: "Nav User",
+      tier: "free" as const,
+      created_at: "2025-01-01T00:00:00Z",
+    },
+    loading: false,
+    error: null,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    clearError: vi.fn(),
+    refreshUser: vi.fn(),
+  }),
+}));
+
+// ── Imports ────────────────────────────────────────────────────────────────────
+
+import { Sidebar } from "@/components/layout/Sidebar";
+import { ResultsTable } from "@/components/results/ResultsTable";
+import type { PaginatedResults, AnalysisResult } from "@debugiq/shared-types";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Sidebar — Settings link", () => {
+  it("renders a link to /settings labeled 'Settings'", () => {
+    render(<Sidebar />);
+    const link = screen.getByRole("link", { name: /settings/i });
+    expect(link).toBeTruthy();
+    expect((link as HTMLAnchorElement).href).toContain("/settings");
+  });
+});
+
+describe("ResultsTable — View links", () => {
+  const makeResult = (id: string): AnalysisResult => ({
+    result_id: id,
+    user_id: "user-1",
+    language: "python",
+    mode: "quick",
+    code_hash: "b".repeat(64),
+    findings_count: 0,
+    findings: [],
+    model_used: "gpt-4o",
+    duration_ms: 500,
+    demo_mode: false,
+    analyzed_at: "2026-01-01T10:00:00Z",
+    created_at: "2026-01-01T10:00:01Z",
+  });
+
+  const mockData: PaginatedResults<AnalysisResult> = {
+    items: [makeResult("r1"), makeResult("r2")],
+    total: 2,
+    page: 1,
+    page_size: 20,
+  };
+
+  it("renders a View link for each row pointing to /results/{id}", () => {
+    render(
+      <ResultsTable
+        data={mockData}
+        loading={false}
+        error={null}
+        page={1}
+        pageSize={20}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    const viewLinks = screen.getAllByText("View →");
+    expect(viewLinks).toHaveLength(2);
+
+    const r1Link = viewLinks[0] as HTMLAnchorElement;
+    expect(r1Link.href).toContain("/results/r1");
+
+    const r2Link = viewLinks[1] as HTMLAnchorElement;
+    expect(r2Link.href).toContain("/results/r2");
+  });
+});

--- a/apps/web/src/test/result-detail.test.tsx
+++ b/apps/web/src/test/result-detail.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Result detail page tests.
+ * Covers: loading state, successful render (metadata + findings),
+ * 404 not-found state, and generic error state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks (hoisted by Vitest above all imports) ────────────────────────────────
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ id: "result-abc123" })),
+  useRouter: vi.fn(() => ({ back: vi.fn() })),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => React.createElement("a", { href, className }, children),
+}));
+
+vi.mock("@/lib/auth/context", () => ({
+  useAuth: () => ({
+    user: {
+      user_id: "user-1",
+      email: "test@example.com",
+      display_name: "Tester",
+      tier: "free" as const,
+      created_at: "2024-01-01T00:00:00Z",
+    },
+    loading: false,
+    error: null,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    clearError: vi.fn(),
+    refreshUser: vi.fn(),
+  }),
+}));
+
+// ── Imports that depend on mocks ───────────────────────────────────────────────
+
+import * as resultsApi from "@/lib/api/results";
+import { ApiError } from "@/lib/api/client";
+import type { AnalysisResult } from "@debugiq/shared-types";
+import ResultDetailPage from "@/app/(app)/results/[id]/page";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const MOCK_RESULT: AnalysisResult = {
+  result_id: "result-abc123",
+  user_id: "user-1",
+  language: "python",
+  mode: "quick",
+  code_hash: "a".repeat(64),
+  findings_count: 2,
+  findings: [
+    {
+      id: "f1",
+      category: "sql_injection",
+      severity: "critical",
+      title: "SQL Injection risk",
+      description: "User input passed directly to query.",
+      line_start: 10,
+      line_end: 12,
+      fix_hint: "Use parameterized queries.",
+    },
+    {
+      id: "f2",
+      category: "bare_exception",
+      severity: "low",
+      title: "Bare exception catch",
+      description: "Catching all exceptions hides real errors.",
+      line_start: 20,
+      line_end: 22,
+    },
+  ],
+  model_used: "gpt-4o",
+  duration_ms: 1200,
+  demo_mode: false,
+  analyzed_at: "2026-03-01T12:00:00Z",
+  created_at: "2026-03-01T12:00:01Z",
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ResultDetailPage — loading", () => {
+  it("shows a spinner while fetching", () => {
+    vi.spyOn(resultsApi, "getResult").mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+    render(<ResultDetailPage />);
+    // Spinner renders an SVG with animate-spin
+    const svgs = document.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+  });
+});
+
+describe("ResultDetailPage — success", () => {
+  it("renders the heading and both finding titles", async () => {
+    vi.spyOn(resultsApi, "getResult").mockResolvedValue(MOCK_RESULT);
+    render(<ResultDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Result Detail")).toBeTruthy(),
+    );
+
+    expect(screen.getByText("SQL Injection risk")).toBeTruthy();
+    expect(screen.getByText("Bare exception catch")).toBeTruthy();
+  });
+
+  it("renders the result_id in the header", async () => {
+    vi.spyOn(resultsApi, "getResult").mockResolvedValue(MOCK_RESULT);
+    render(<ResultDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(MOCK_RESULT.result_id)).toBeTruthy(),
+    );
+  });
+
+  it("shows severity summary with critical count", async () => {
+    vi.spyOn(resultsApi, "getResult").mockResolvedValue(MOCK_RESULT);
+    render(<ResultDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Result Detail")).toBeTruthy(),
+    );
+    // "Severity Summary" heading should be visible
+    expect(screen.getByText("Severity Summary")).toBeTruthy();
+    // fix_hint is rendered inside the finding card
+    expect(screen.getByText("Use parameterized queries.")).toBeTruthy();
+  });
+});
+
+describe("ResultDetailPage — 404", () => {
+  it("shows the not-found message on a 404 ApiError", async () => {
+    vi.spyOn(resultsApi, "getResult").mockRejectedValue(
+      new ApiError(404, "result_not_found"),
+    );
+    render(<ResultDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Result not found")).toBeTruthy(),
+    );
+  });
+});
+
+describe("ResultDetailPage — generic error", () => {
+  it("shows the error heading on a 500 ApiError", async () => {
+    vi.spyOn(resultsApi, "getResult").mockRejectedValue(
+      new ApiError(500, "internal_error"),
+    );
+    render(<ResultDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Error loading result")).toBeTruthy(),
+    );
+    expect(screen.getByText("internal_error")).toBeTruthy();
+  });
+});

--- a/apps/web/src/test/settings.test.tsx
+++ b/apps/web/src/test/settings.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Settings page tests.
+ * Covers: renders user info, successful display_name update, error on failure.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockRefreshUser = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/auth/context", () => ({
+  useAuth: () => ({
+    user: {
+      user_id: "user-1",
+      email: "settings@example.com",
+      display_name: "Old Name",
+      tier: "free" as const,
+      created_at: "2025-06-01T00:00:00Z",
+    },
+    loading: false,
+    error: null,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    clearError: vi.fn(),
+    refreshUser: mockRefreshUser,
+  }),
+}));
+
+// ── Imports ────────────────────────────────────────────────────────────────────
+
+import * as usersApi from "@/lib/api/users";
+import { ApiError } from "@/lib/api/client";
+import type { UserResponse } from "@debugiq/shared-types";
+import SettingsPage from "@/app/(app)/settings/page";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockRefreshUser.mockResolvedValue(undefined);
+});
+
+describe("SettingsPage — renders user info", () => {
+  it("shows the user's email", () => {
+    render(<SettingsPage />);
+    expect(screen.getByText("settings@example.com")).toBeTruthy();
+  });
+
+  it("shows the user's tier", () => {
+    render(<SettingsPage />);
+    expect(screen.getByText("free")).toBeTruthy();
+  });
+
+  it("pre-populates the display name input", () => {
+    render(<SettingsPage />);
+    const input = screen.getByRole("textbox", { name: /display name/i });
+    expect((input as HTMLInputElement).value).toBe("Old Name");
+  });
+});
+
+describe("SettingsPage — successful save", () => {
+  it("shows the success banner after patchMe resolves", async () => {
+    const patchedUser: UserResponse = {
+      user_id: "user-1",
+      email: "settings@example.com",
+      display_name: "New Name",
+      tier: "free",
+      created_at: "2025-06-01T00:00:00Z",
+    };
+    vi.spyOn(usersApi, "patchMe").mockResolvedValue(patchedUser);
+
+    render(<SettingsPage />);
+
+    const input = screen.getByRole("textbox", { name: /display name/i });
+    fireEvent.change(input, { target: { value: "New Name" } });
+
+    fireEvent.submit(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Profile updated successfully.")).toBeTruthy(),
+    );
+
+    expect(usersApi.patchMe).toHaveBeenCalledWith({
+      display_name: "New Name",
+    });
+    expect(mockRefreshUser).toHaveBeenCalled();
+  });
+});
+
+describe("SettingsPage — error on save", () => {
+  it("shows an error banner when patchMe rejects", async () => {
+    vi.spyOn(usersApi, "patchMe").mockRejectedValue(
+      new ApiError(422, "validation_error"),
+    );
+
+    render(<SettingsPage />);
+
+    fireEvent.submit(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toBeTruthy(),
+    );
+    expect(screen.getByText("validation_error")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- Add /results/[id] page: fetches result by id, renders metadata (language, mode, model, duration, severity summary) and all findings with title, lines, category, description, fix_hint/explanation
- Add /settings page: shows user profile (email, tier, member since) with editable display_name, optimistic success/error feedback
- Wire result detail: add 'View →' link per row in ResultsTable
- Wire settings: add Settings nav item to Sidebar
- Add refreshUser() to AuthContext so settings page syncs the sidebar
- Add .eslintrc.json (next/core-web-vitals) — was missing, blocked lint
- Add 13 new tests across result-detail, settings, and navigation suites (27 total, all passing)