### PR TITLE
feat(teams): add team analytics summary endpoint and dashboard panel

### DIFF
--- a/apps/api/src/teams/router.py
+++ b/apps/api/src/teams/router.py
@@ -4,7 +4,8 @@ Teams router — /v0/teams
 
 import uuid
 from collections.abc import Generator
-from typing import Literal
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -12,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.dependencies import get_current_user
-from src.db.models import Team, TeamMember, User
+from src.db.models import AnalysisResult, Team, TeamMember, User
 from src.db.session import get_db
 
 router = APIRouter(prefix="/teams", tags=["teams"])
@@ -42,6 +43,34 @@ class TeamMemberResponse(BaseModel):
 class AddMemberRequest(BaseModel):
     email: str
     role: Literal["admin", "member"]
+
+
+class SeverityCounts(BaseModel):
+    critical: int
+    high: int
+    medium: int
+    low: int
+    info: int
+
+
+class ModeCounts(BaseModel):
+    quick: int
+    learn: int
+
+
+class LanguageCounts(BaseModel):
+    python: int
+    typescript: int
+
+
+class TeamAnalyticsSummary(BaseModel):
+    total_results: int
+    results_last_7d: int
+    results_last_30d: int
+    severity_counts: SeverityCounts
+    mode_counts: ModeCounts
+    language_counts: LanguageCounts
+    active_members_last_30d: int
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -81,6 +110,13 @@ def _to_team_response(team: Team) -> TeamResponse:
 
 def _get_db_gen() -> Generator[Session, None, None]:
     yield from get_db()
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Return a UTC-aware datetime regardless of whether dt carries tzinfo."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
 
 
 # ── Endpoints ──────────────────────────────────────────────────────────────────
@@ -177,3 +213,54 @@ def add_member(
         raise HTTPException(status_code=409, detail="already_a_member")
 
     return TeamMemberResponse(user_id=str(target.id), email=target.email, role=body.role)
+
+
+@router.get("/{team_id}/analytics/summary", response_model=TeamAnalyticsSummary)
+def get_team_analytics_summary(
+    team_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TeamAnalyticsSummary:
+    team = _get_team_or_404(db, team_id)
+    _require_member(db, team, current_user)
+
+    results: list[AnalysisResult] = (
+        db.query(AnalysisResult).filter(AnalysisResult.team_id == team.id).all()
+    )
+
+    now = datetime.now(UTC)
+    cutoff_7d = now - timedelta(days=7)
+    cutoff_30d = now - timedelta(days=30)
+
+    total_results = len(results)
+    results_last_7d = sum(1 for r in results if _ensure_utc(r.created_at) >= cutoff_7d)
+    results_last_30d = sum(1 for r in results if _ensure_utc(r.created_at) >= cutoff_30d)
+
+    sev: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+    for r in results:
+        for finding in r.findings:
+            s = str(finding.get("severity", "")) if isinstance(finding, dict) else ""
+            if s in sev:
+                sev[s] += 1
+
+    mode: dict[str, int] = {"quick": 0, "learn": 0}
+    for r in results:
+        if r.mode in mode:
+            mode[r.mode] += 1
+
+    lang: dict[str, int] = {"python": 0, "typescript": 0}
+    for r in results:
+        if r.language in lang:
+            lang[r.language] += 1
+
+    active_users: set[Any] = {r.user_id for r in results if _ensure_utc(r.created_at) >= cutoff_30d}
+
+    return TeamAnalyticsSummary(
+        total_results=total_results,
+        results_last_7d=results_last_7d,
+        results_last_30d=results_last_30d,
+        severity_counts=SeverityCounts(**sev),
+        mode_counts=ModeCounts(**mode),
+        language_counts=LanguageCounts(**lang),
+        active_members_last_30d=len(active_users),
+    )

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -389,3 +389,167 @@ def test_get_result_team_member_can_access(client):
     get_res = client.get(f"/v0/results/{result_id}", headers=_auth_headers(tok_member))
     assert get_res.status_code == 200
     assert get_res.json()["result_id"] == result_id
+
+
+# ── Team analytics summary ─────────────────────────────────────────────────────
+
+
+def _save_team_result(
+    client,
+    headers: dict,
+    team_id: str,
+    language: str = "python",
+    mode: str = "quick",
+    findings: list | None = None,
+    seed: str = "default",
+) -> dict:
+    if findings is None:
+        findings = []
+    res = client.post(
+        "/v0/results",
+        json={
+            "language": language,
+            "mode": mode,
+            "code_hash": _make_hash(seed),
+            "findings": findings,
+            "model_used": "gpt-4o",
+            "demo_mode": False,
+            "analyzed_at": "2026-04-01T12:00:00Z",
+            "team_id": team_id,
+        },
+        headers=headers,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+def test_analytics_summary_non_member_returns_403(client):
+    tok_owner = _register_and_login(client, "anl_owner@example.com")
+    tok_other = _register_and_login(client, "anl_outsider@example.com")
+    team = _create_team(client, _auth_headers(tok_owner))
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/summary",
+        headers=_auth_headers(tok_other),
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"] == "not_a_member"
+
+
+def test_analytics_summary_invalid_team_id_returns_404(client):
+    tokens = _register_and_login(client, "anl_invalid@example.com")
+    res = client.get(
+        "/v0/teams/not-a-uuid/analytics/summary",
+        headers=_auth_headers(tokens),
+    )
+    assert res.status_code == 404
+
+
+def test_analytics_summary_empty_team(client):
+    tokens = _register_and_login(client, "anl_empty@example.com")
+    headers = _auth_headers(tokens)
+    team = _create_team(client, headers, name="Empty Analytics Team")
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/summary",
+        headers=headers,
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total_results"] == 0
+    assert data["results_last_7d"] == 0
+    assert data["results_last_30d"] == 0
+    assert data["active_members_last_30d"] == 0
+    # severity/mode/language counts all zero
+    for v in data["severity_counts"].values():
+        assert v == 0
+    for v in data["mode_counts"].values():
+        assert v == 0
+    for v in data["language_counts"].values():
+        assert v == 0
+
+
+def test_analytics_summary_shape_and_counts(client):
+    tok_owner = _register_and_login(client, "anl_shape_owner@example.com")
+    tok_member = _register_and_login(client, "anl_shape_member@example.com")
+    headers_owner = _auth_headers(tok_owner)
+    headers_member = _auth_headers(tok_member)
+
+    team = _create_team(client, headers_owner, name="Shape Analytics Team")
+    # Add a second member
+    client.post(
+        f"/v0/teams/{team['team_id']}/members",
+        json={"email": "anl_shape_member@example.com", "role": "member"},
+        headers=headers_owner,
+    )
+
+    critical_finding = {
+        "id": "f1",
+        "category": "sql_injection",
+        "severity": "critical",
+        "title": "SQL Injection",
+        "description": "desc",
+        "line_start": 1,
+        "line_end": 2,
+    }
+
+    # Owner saves a Python/quick result with 1 critical finding
+    _save_team_result(
+        client,
+        headers_owner,
+        team["team_id"],
+        language="python",
+        mode="quick",
+        findings=[critical_finding],
+        seed="shape-py-1",
+    )
+
+    # Member saves a TypeScript/learn result with no findings
+    _save_team_result(
+        client,
+        headers_member,
+        team["team_id"],
+        language="typescript",
+        mode="learn",
+        findings=[],
+        seed="shape-ts-1",
+    )
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/summary",
+        headers=headers_owner,
+    )
+    assert res.status_code == 200
+    data = res.json()
+
+    # Required keys present
+    for key in (
+        "total_results",
+        "results_last_7d",
+        "results_last_30d",
+        "severity_counts",
+        "mode_counts",
+        "language_counts",
+        "active_members_last_30d",
+    ):
+        assert key in data, f"missing key: {key}"
+
+    assert data["total_results"] == 2
+    # Both results were just created — should appear in 7d and 30d windows
+    assert data["results_last_7d"] == 2
+    assert data["results_last_30d"] == 2
+
+    # Severity: 1 critical from the first result
+    assert data["severity_counts"]["critical"] == 1
+    assert data["severity_counts"]["high"] == 0
+
+    # Mode breakdown
+    assert data["mode_counts"]["quick"] == 1
+    assert data["mode_counts"]["learn"] == 1
+
+    # Language breakdown
+    assert data["language_counts"]["python"] == 1
+    assert data["language_counts"]["typescript"] == 1
+
+    # Two distinct users contributed
+    assert data["active_members_last_30d"] == 2

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
   },
   "devDependencies": {
     "@debugiq/shared-types": "workspace:*",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { ResultsTable } from "@/components/results/ResultsTable";
 import { ResultFilters } from "@/components/results/ResultFilters";
 import { useAuth } from "@/lib/auth/context";
 import { useWorkspace } from "@/lib/workspace/context";
+import { TeamAnalyticsPanel } from "@/components/teams/TeamAnalyticsPanel";
 
 const PAGE_SIZE = 20;
 
@@ -62,6 +63,11 @@ export default function DashboardPage() {
       {/* Summary stats */}
       {data && !loading && (
         <DashboardStats data={data} />
+      )}
+
+      {/* Team analytics panel (team scope only) */}
+      {scope !== "personal" && (
+        <TeamAnalyticsPanel teamId={scope.id} />
       )}
 
       {/* Filters */}

--- a/apps/web/src/components/teams/TeamAnalyticsPanel.tsx
+++ b/apps/web/src/components/teams/TeamAnalyticsPanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+/**
+ * apps/web/src/components/teams/TeamAnalyticsPanel.tsx
+ *
+ * Renders team-level analytics summary fetched from
+ * GET /v0/teams/{teamId}/analytics/summary.
+ */
+
+import { useState, useEffect } from "react";
+import type { ReactNode } from "react";
+import type { TeamAnalyticsSummary } from "@debugiq/shared-types";
+import { getTeamAnalyticsSummary } from "@/lib/api/teams";
+import { ApiError } from "@/lib/api/client";
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-surface-1 px-5 py-4">
+      <p className="text-xs text-muted">{label}</p>
+      <p className="mt-1 text-2xl font-bold tabular-nums text-white">{value}</p>
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-surface-1 px-5 py-4">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function CountGrid({
+  entries,
+}: {
+  entries: { label: string; value: number }[];
+}) {
+  return (
+    <dl
+      className="grid gap-2"
+      style={{ gridTemplateColumns: `repeat(${entries.length}, minmax(0, 1fr))` }}
+    >
+      {entries.map(({ label, value }) => (
+        <div key={label} className="text-center">
+          <dt className="text-xs capitalize text-muted">{label}</dt>
+          <dd className="text-lg font-bold tabular-nums text-white">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// ── Main panel ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  teamId: string;
+}
+
+export function TeamAnalyticsPanel({ teamId }: Props) {
+  const [data, setData] = useState<TeamAnalyticsSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setData(null);
+    getTeamAnalyticsSummary(teamId)
+      .then(setData)
+      .catch((err) => {
+        setError(
+          err instanceof ApiError ? err.detail : "Failed to load team analytics.",
+        );
+      })
+      .finally(() => setLoading(false));
+  }, [teamId]);
+
+  if (loading) {
+    return (
+      <div data-testid="analytics-loading" className="text-sm text-muted">
+        Loading analytics…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div data-testid="analytics-error" className="text-sm text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const sevEntries = (
+    ["critical", "high", "medium", "low", "info"] as const
+  ).map((k) => ({ label: k, value: data.severity_counts[k] }));
+
+  const modeEntries = (["quick", "learn"] as const).map((k) => ({
+    label: k,
+    value: data.mode_counts[k],
+  }));
+
+  const langEntries = (["python", "typescript"] as const).map((k) => ({
+    label: k,
+    value: data.language_counts[k],
+  }));
+
+  return (
+    <div data-testid="analytics-panel" className="flex flex-col gap-4">
+      {/* Headline counters */}
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard label="Total analyses" value={String(data.total_results)} />
+        <StatCard label="Last 7 days" value={String(data.results_last_7d)} />
+        <StatCard label="Last 30 days" value={String(data.results_last_30d)} />
+      </div>
+
+      {/* Severity */}
+      <SectionCard title="Severity breakdown">
+        <CountGrid entries={sevEntries} />
+      </SectionCard>
+
+      {/* Mode + Language */}
+      <div className="grid grid-cols-2 gap-4">
+        <SectionCard title="By mode">
+          <CountGrid entries={modeEntries} />
+        </SectionCard>
+        <SectionCard title="By language">
+          <CountGrid entries={langEntries} />
+        </SectionCard>
+      </div>
+
+      {/* Active members */}
+      <StatCard
+        label="Active members (last 30d)"
+        value={String(data.active_members_last_30d)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/teams.ts
+++ b/apps/web/src/lib/api/teams.ts
@@ -3,7 +3,7 @@
  * Teams endpoint wrappers.
  */
 
-import type { TeamResponse, CreateTeamRequest, TeamMemberResponse, AddMemberRequest } from "@debugiq/shared-types";
+import type { TeamResponse, CreateTeamRequest, TeamMemberResponse, AddMemberRequest, TeamAnalyticsSummary } from "@debugiq/shared-types";
 import { apiFetch } from "./client";
 
 export function listTeams(): Promise<TeamResponse[]> {
@@ -32,4 +32,8 @@ export function addTeamMember(teamId: string, body: AddMemberRequest): Promise<T
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+export function getTeamAnalyticsSummary(teamId: string): Promise<TeamAnalyticsSummary> {
+  return apiFetch<TeamAnalyticsSummary>(`/v0/teams/${teamId}/analytics/summary`);
 }

--- a/apps/web/src/test/team-analytics.test.tsx
+++ b/apps/web/src/test/team-analytics.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * TeamAnalyticsPanel tests.
+ * Covers: loading state, successful render, and error state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act, within } from "@testing-library/react";
+import React from "react";
+import * as teamsApi from "@/lib/api/teams";
+import { TeamAnalyticsPanel } from "@/components/teams/TeamAnalyticsPanel";
+import { ApiError } from "@/lib/api/client";
+import type { TeamAnalyticsSummary } from "@debugiq/shared-types";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const MOCK_SUMMARY: TeamAnalyticsSummary = {
+  total_results: 10,
+  results_last_7d: 3,
+  results_last_30d: 7,
+  severity_counts: { critical: 1, high: 2, medium: 3, low: 1, info: 0 },
+  mode_counts: { quick: 6, learn: 4 },
+  language_counts: { python: 8, typescript: 2 },
+  active_members_last_30d: 2,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("TeamAnalyticsPanel — loading", () => {
+  it("renders the loading indicator while the request is in-flight", () => {
+    vi.spyOn(teamsApi, "getTeamAnalyticsSummary").mockReturnValue(
+      new Promise(() => {}), // never resolves
+    );
+    render(<TeamAnalyticsPanel teamId="team-abc" />);
+    expect(screen.getByTestId("analytics-loading")).toBeTruthy();
+  });
+});
+
+describe("TeamAnalyticsPanel — success", () => {
+  it("renders the analytics panel with summary data", async () => {
+    vi.spyOn(teamsApi, "getTeamAnalyticsSummary").mockResolvedValue(MOCK_SUMMARY);
+
+    await act(async () => {
+      render(<TeamAnalyticsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("analytics-panel")).toBeTruthy();
+  });
+
+  it("displays correct headline counters", async () => {
+    vi.spyOn(teamsApi, "getTeamAnalyticsSummary").mockResolvedValue(MOCK_SUMMARY);
+
+    await act(async () => {
+      render(<TeamAnalyticsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByText("10")).toBeTruthy(); // total_results
+    // Use the labeled stat card to avoid ambiguity with severity counts
+    const last7dCard = screen.getByText("Last 7 days").closest("div")!;
+    expect(within(last7dCard).getByText("3")).toBeTruthy(); // results_last_7d
+    expect(screen.getByText("7")).toBeTruthy();  // results_last_30d
+    const activeMembersCard = screen.getByText("Active members (last 30d)").closest("div")!;
+    expect(within(activeMembersCard).getByText("2")).toBeTruthy(); // active_members_last_30d
+  });
+});
+
+describe("TeamAnalyticsPanel — error", () => {
+  it("renders the error state when the request fails", async () => {
+    vi.spyOn(teamsApi, "getTeamAnalyticsSummary").mockRejectedValue(
+      new ApiError(403, "not_a_member"),
+    );
+
+    await act(async () => {
+      render(<TeamAnalyticsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("analytics-error")).toBeTruthy();
+    expect(screen.getByText("not_a_member")).toBeTruthy();
+  });
+
+  it("shows generic message for non-ApiError failures", async () => {
+    vi.spyOn(teamsApi, "getTeamAnalyticsSummary").mockRejectedValue(
+      new Error("network failure"),
+    );
+
+    await act(async () => {
+      render(<TeamAnalyticsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("analytics-error")).toBeTruthy();
+    expect(screen.getByText("Failed to load team analytics.")).toBeTruthy();
+  });
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -18,7 +18,9 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "plugins": [
       {
@@ -29,7 +31,8 @@
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -130,3 +130,33 @@ export interface AddMemberRequest {
   email: string;
   role: "admin" | "member";
 }
+
+// ── Team Analytics API Shapes ─────────────────────────────────────────────────
+
+export interface SeverityCounts {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+}
+
+export interface ModeCounts {
+  quick: number;
+  learn: number;
+}
+
+export interface LanguageCounts {
+  python: number;
+  typescript: number;
+}
+
+export interface TeamAnalyticsSummary {
+  total_results: number;
+  results_last_7d: number;
+  results_last_30d: number;
+  severity_counts: SeverityCounts;
+  mode_counts: ModeCounts;
+  language_counts: LanguageCounts;
+  active_members_last_30d: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,16 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@5.4.21(@types/node@20.19.37))
@@ -798,6 +804,17 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
   '@types/vscode@1.110.0':
     resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
 
@@ -1354,6 +1371,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -3822,12 +3842,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -3868,6 +3891,17 @@ snapshots:
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@types/vscode@1.110.0': {}
 
@@ -4487,6 +4521,8 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  csstype@3.2.3: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0:
@@ -4784,8 +4820,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4804,7 +4840,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4815,22 +4851,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4841,7 +4877,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

This PR adds Team Analytics v1 for the new team workspace flow.

It introduces:
- A backend team analytics summary endpoint
- A web dashboard panel for team-scoped metrics
- Type/test hardening needed to keep CI stable

## What was implemented

### API
- Added team analytics summary endpoint under teams routes
- Enforced team membership authorization
- Exposed compact summary metrics for MVP dashboards

### Web
- Added/updated Team Analytics panel in team scope
- Added clear loading/error/data states
- Wired rendering to team context and analytics API response

### Type/Test hardening
- Added `@types/react` and `@types/react-dom` (v18) in `apps/web` devDependencies to fix typecheck failures
- Replaced `React.ReactNode` namespace usage with `import type { ReactNode } from "react"`
- Fixed ambiguous `getByText("3")` assertion in team analytics test using `within()` scoping

## Validation

All required checks pass locally:

- API:
  - `ruff check` ✅
  - `mypy src` ✅
  - `pytest` ✅ (53 passed)
- Web:
  - `pnpm lint` ✅
  - `pnpm typecheck` ✅
  - `pnpm test` ✅ (23 passed, 5 files)
- Shared types:
  - `pnpm --filter @debugiq/shared-types typecheck` ✅

## Scope notes

- This is MVP analytics summary and dashboard support.
- Advanced analytics visualizations and deeper team insights are intentionally deferred to a follow-up PR.