### PR TITLE
feat(teams): add team insights endpoint and dashboard insights panel

### DIFF
--- a/apps/api/src/teams/router.py
+++ b/apps/api/src/teams/router.py
@@ -5,7 +5,7 @@ Teams router — /v0/teams
 import uuid
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -71,6 +71,34 @@ class TeamAnalyticsSummary(BaseModel):
     mode_counts: ModeCounts
     language_counts: LanguageCounts
     active_members_last_30d: int
+
+
+class DailyResultCount(BaseModel):
+    date: str  # ISO date YYYY-MM-DD
+    count: int
+
+
+class CategoryCount(BaseModel):
+    category: str
+    count: int
+
+
+class SignatureCount(BaseModel):
+    signature_hash: str
+    count: int
+
+
+class MemberActivityEntry(BaseModel):
+    user_id: str
+    display_name: str | None
+    results_count: int
+
+
+class TeamInsights(BaseModel):
+    daily_results_last_14d: list[DailyResultCount]
+    top_bug_categories_last_30d: list[CategoryCount]
+    top_signatures_last_30d: list[SignatureCount]
+    member_activity_last_30d: list[MemberActivityEntry]
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -253,7 +281,9 @@ def get_team_analytics_summary(
         if r.language in lang:
             lang[r.language] += 1
 
-    active_users: set[Any] = {r.user_id for r in results if _ensure_utc(r.created_at) >= cutoff_30d}
+    active_users: set[uuid.UUID] = {
+        r.user_id for r in results if _ensure_utc(r.created_at) >= cutoff_30d
+    }
 
     return TeamAnalyticsSummary(
         total_results=total_results,
@@ -263,4 +293,82 @@ def get_team_analytics_summary(
         mode_counts=ModeCounts(**mode),
         language_counts=LanguageCounts(**lang),
         active_members_last_30d=len(active_users),
+    )
+
+
+@router.get("/{team_id}/analytics/insights", response_model=TeamInsights)
+def get_team_analytics_insights(
+    team_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TeamInsights:
+    team = _get_team_or_404(db, team_id)
+    _require_member(db, team, current_user)
+
+    all_results: list[AnalysisResult] = (
+        db.query(AnalysisResult).filter(AnalysisResult.team_id == team.id).all()
+    )
+
+    now = datetime.now(UTC)
+    cutoff_14d = now - timedelta(days=14)
+    cutoff_30d = now - timedelta(days=30)
+
+    results_last_30d = [r for r in all_results if _ensure_utc(r.created_at) >= cutoff_30d]
+    results_last_14d = [r for r in results_last_30d if _ensure_utc(r.created_at) >= cutoff_14d]
+
+    # ── Daily activity: build a full 14-day range, fill zeros for missing days ──
+    daily_counts: dict[str, int] = {
+        (now - timedelta(days=13 - i)).date().isoformat(): 0 for i in range(14)
+    }
+    for r in results_last_14d:
+        day = _ensure_utc(r.created_at).date().isoformat()
+        if day in daily_counts:
+            daily_counts[day] += 1
+    daily_results_last_14d = [
+        DailyResultCount(date=d, count=c) for d, c in sorted(daily_counts.items())
+    ]
+
+    # ── Top bug categories: aggregate finding.category from last 30d ──────────
+    category_counts: dict[str, int] = {}
+    for r in results_last_30d:
+        for finding in r.findings:
+            if isinstance(finding, dict):
+                cat = str(finding.get("category", "")).strip()
+                if cat:
+                    category_counts[cat] = category_counts.get(cat, 0) + 1
+    top_bug_categories_last_30d = [
+        CategoryCount(category=cat, count=cnt)
+        for cat, cnt in sorted(category_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+    ]
+
+    # ── Top signatures: group by code_hash from last 30d ─────────────────────
+    sig_counts: dict[str, int] = {}
+    for r in results_last_30d:
+        sig_counts[r.code_hash] = sig_counts.get(r.code_hash, 0) + 1
+    top_signatures_last_30d = [
+        SignatureCount(signature_hash=sig, count=cnt)
+        for sig, cnt in sorted(sig_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+    ]
+
+    # ── Member activity: group by user_id, join display_name ──────────────────
+    member_counts: dict[uuid.UUID, int] = {}
+    for r in results_last_30d:
+        member_counts[r.user_id] = member_counts.get(r.user_id, 0) + 1
+
+    member_activity_last_30d: list[MemberActivityEntry] = []
+    for uid, cnt in sorted(member_counts.items(), key=lambda x: x[1], reverse=True):
+        user = db.query(User).filter(User.id == uid).first()
+        member_activity_last_30d.append(
+            MemberActivityEntry(
+                user_id=str(uid),
+                display_name=user.display_name if user else None,
+                results_count=cnt,
+            )
+        )
+
+    return TeamInsights(
+        daily_results_last_14d=daily_results_last_14d,
+        top_bug_categories_last_30d=top_bug_categories_last_30d,
+        top_signatures_last_30d=top_signatures_last_30d,
+        member_activity_last_30d=member_activity_last_30d,
     )

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -553,3 +553,123 @@ def test_analytics_summary_shape_and_counts(client):
 
     # Two distinct users contributed
     assert data["active_members_last_30d"] == 2
+
+
+# ── Team analytics insights ────────────────────────────────────────────────────
+
+
+def test_insights_non_member_returns_403(client):
+    tok_owner = _register_and_login(client, "ins_owner@example.com")
+    tok_other = _register_and_login(client, "ins_outsider@example.com")
+    team = _create_team(client, _auth_headers(tok_owner))
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/insights",
+        headers=_auth_headers(tok_other),
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"] == "not_a_member"
+
+
+def test_insights_invalid_team_returns_404(client):
+    tokens = _register_and_login(client, "ins_invalid@example.com")
+    res = client.get(
+        "/v0/teams/not-a-uuid/analytics/insights",
+        headers=_auth_headers(tokens),
+    )
+    assert res.status_code == 404
+
+
+def test_insights_empty_team(client):
+    tokens = _register_and_login(client, "ins_empty@example.com")
+    headers = _auth_headers(tokens)
+    team = _create_team(client, headers, name="Empty Insights Team")
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/insights",
+        headers=headers,
+    )
+    assert res.status_code == 200
+    data = res.json()
+
+    # Always 14 daily entries, all zeros
+    assert len(data["daily_results_last_14d"]) == 14
+    for entry in data["daily_results_last_14d"]:
+        assert entry["count"] == 0
+
+    assert data["top_bug_categories_last_30d"] == []
+    assert data["top_signatures_last_30d"] == []
+    assert data["member_activity_last_30d"] == []
+
+
+def test_insights_shape_and_data(client):
+    tok_owner = _register_and_login(client, "ins_shape_owner@example.com")
+    tok_member = _register_and_login(client, "ins_shape_member@example.com")
+    headers_owner = _auth_headers(tok_owner)
+    headers_member = _auth_headers(tok_member)
+
+    team = _create_team(client, headers_owner, name="Insights Shape Team")
+    client.post(
+        f"/v0/teams/{team['team_id']}/members",
+        json={"email": "ins_shape_member@example.com", "role": "member"},
+        headers=headers_owner,
+    )
+
+    sql_finding = {
+        "id": "f1",
+        "category": "sql_injection",
+        "severity": "critical",
+        "title": "SQL Injection",
+        "description": "desc",
+        "line_start": 1,
+        "line_end": 2,
+    }
+
+    # Owner saves 2 results with same code_hash (repeated signature)
+    _save_team_result(
+        client, headers_owner, team["team_id"], findings=[sql_finding], seed="ins-common"
+    )
+    _save_team_result(
+        client, headers_owner, team["team_id"], findings=[sql_finding], seed="ins-common"
+    )
+    # Member saves 1 result with a different signature
+    _save_team_result(client, headers_member, team["team_id"], findings=[], seed="ins-other")
+
+    res = client.get(
+        f"/v0/teams/{team['team_id']}/analytics/insights",
+        headers=headers_owner,
+    )
+    assert res.status_code == 200
+    data = res.json()
+
+    # Shape checks
+    for key in (
+        "daily_results_last_14d",
+        "top_bug_categories_last_30d",
+        "top_signatures_last_30d",
+        "member_activity_last_30d",
+    ):
+        assert key in data, f"missing key: {key}"
+
+    # 14-day daily entries; total for today should be 3
+    assert len(data["daily_results_last_14d"]) == 14
+    today_count = data["daily_results_last_14d"][-1]["count"]
+    assert today_count == 3
+
+    # Categories: sql_injection appears in 2 findings
+    cats = {c["category"]: c["count"] for c in data["top_bug_categories_last_30d"]}
+    assert "sql_injection" in cats
+    assert cats["sql_injection"] == 2
+
+    # Signatures: ins-common hash repeated twice → count=2; ins-other → count=1
+    assert len(data["top_signatures_last_30d"]) == 2
+    top_sig = data["top_signatures_last_30d"][0]
+    assert top_sig["signature_hash"] == _make_hash("ins-common")
+    assert top_sig["count"] == 2
+
+    # Member activity: owner has 2 results, member has 1
+    assert len(data["member_activity_last_30d"]) == 2
+    counts = sorted(m["results_count"] for m in data["member_activity_last_30d"])
+    assert counts == [1, 2]
+    # Ranked descending: first entry is the owner with 2 results
+    assert data["member_activity_last_30d"][0]["results_count"] == 2

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { ResultFilters } from "@/components/results/ResultFilters";
 import { useAuth } from "@/lib/auth/context";
 import { useWorkspace } from "@/lib/workspace/context";
 import { TeamAnalyticsPanel } from "@/components/teams/TeamAnalyticsPanel";
+import { TeamInsightsPanel } from "@/components/teams/TeamInsightsPanel";
 
 const PAGE_SIZE = 20;
 
@@ -68,6 +69,11 @@ export default function DashboardPage() {
       {/* Team analytics panel (team scope only) */}
       {scope !== "personal" && (
         <TeamAnalyticsPanel teamId={scope.id} />
+      )}
+
+      {/* Team insights panel (team scope only) */}
+      {scope !== "personal" && (
+        <TeamInsightsPanel teamId={scope.id} />
       )}
 
       {/* Filters */}

--- a/apps/web/src/components/teams/TeamInsightsPanel.tsx
+++ b/apps/web/src/components/teams/TeamInsightsPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+/**
+ * apps/web/src/components/teams/TeamInsightsPanel.tsx
+ *
+ * Renders team insights: 14-day trend, top categories, top signatures,
+ * and member activity ranking. Fetched from
+ * GET /v0/teams/{teamId}/analytics/insights.
+ */
+
+import { useState, useEffect } from "react";
+import type { ReactNode } from "react";
+import type { TeamInsights } from "@debugiq/shared-types";
+import { getTeamInsights } from "@/lib/api/teams";
+import { ApiError } from "@/lib/api/client";
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function InsightSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-surface-1 px-5 py-4">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function EmptyNote({ message }: { message: string }) {
+  return <p className="text-xs text-muted">{message}</p>;
+}
+
+// ── Main component ──────────────────────────────────────────────────────────────
+
+interface Props {
+  teamId: string;
+}
+
+export function TeamInsightsPanel({ teamId }: Props) {
+  const [data, setData] = useState<TeamInsights | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setData(null);
+    getTeamInsights(teamId)
+      .then(setData)
+      .catch((err) => {
+        setError(
+          err instanceof ApiError ? err.detail : "Failed to load team insights.",
+        );
+      })
+      .finally(() => setLoading(false));
+  }, [teamId]);
+
+  if (loading) {
+    return (
+      <div data-testid="insights-loading" className="text-sm text-muted">
+        Loading insights…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div data-testid="insights-error" className="text-sm text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const allZero = data.daily_results_last_14d.every((d) => d.count === 0);
+  const maxDay = Math.max(...data.daily_results_last_14d.map((d) => d.count), 1);
+
+  return (
+    <div data-testid="insights-panel" className="flex flex-col gap-4">
+      {/* 14-day activity trend */}
+      <InsightSection title="14-day activity trend">
+        {allZero ? (
+          <EmptyNote message="No activity in the last 14 days." />
+        ) : (
+          <div
+            data-testid="trend-bars"
+            className="flex items-end gap-[3px]"
+            style={{ height: "48px" }}
+          >
+            {data.daily_results_last_14d.map(({ date, count }) => (
+              <div
+                key={date}
+                className="flex flex-1 flex-col items-center justify-end"
+                style={{ height: "100%" }}
+                title={`${date}: ${count}`}
+              >
+                <div
+                  className="w-full rounded-sm bg-indigo-500"
+                  style={{
+                    height: count === 0 ? "2px" : `${Math.round((count / maxDay) * 100)}%`,
+                    opacity: count === 0 ? 0.2 : 1,
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </InsightSection>
+
+      {/* Top bug categories + top signatures */}
+      <div className="grid grid-cols-2 gap-4">
+        <InsightSection title="Top bug categories (30d)">
+          {data.top_bug_categories_last_30d.length === 0 ? (
+            <EmptyNote message="No findings recorded yet." />
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {data.top_bug_categories_last_30d.map(({ category, count }) => (
+                <li key={category} className="flex items-center justify-between text-sm">
+                  <span className="capitalize text-white">
+                    {category.replace(/_/g, " ")}
+                  </span>
+                  <span className="tabular-nums text-muted">{count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </InsightSection>
+
+        <InsightSection title="Top signatures (30d)">
+          {data.top_signatures_last_30d.length === 0 ? (
+            <EmptyNote message="No signatures recorded yet." />
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {data.top_signatures_last_30d.map(({ signature_hash, count }) => (
+                <li
+                  key={signature_hash}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="font-mono text-xs text-white">
+                    {signature_hash.slice(0, 12)}&hellip;
+                  </span>
+                  <span className="tabular-nums text-muted">{count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </InsightSection>
+      </div>
+
+      {/* Member activity ranking */}
+      <InsightSection title="Member activity (30d)">
+        {data.member_activity_last_30d.length === 0 ? (
+          <EmptyNote message="No member activity in the last 30 days." />
+        ) : (
+          <ol className="flex flex-col gap-2">
+            {data.member_activity_last_30d.map(({ user_id, display_name, results_count }, idx) => (
+              <li key={user_id} className="flex items-center gap-3 text-sm">
+                <span className="w-4 text-right tabular-nums text-muted">{idx + 1}.</span>
+                <span className="flex-1 truncate text-white">
+                  {display_name ?? `${user_id.slice(0, 8)}…`}
+                </span>
+                <span className="tabular-nums text-muted">{results_count}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </InsightSection>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/teams.ts
+++ b/apps/web/src/lib/api/teams.ts
@@ -3,7 +3,7 @@
  * Teams endpoint wrappers.
  */
 
-import type { TeamResponse, CreateTeamRequest, TeamMemberResponse, AddMemberRequest, TeamAnalyticsSummary } from "@debugiq/shared-types";
+import type { TeamResponse, CreateTeamRequest, TeamMemberResponse, AddMemberRequest, TeamAnalyticsSummary, TeamInsights } from "@debugiq/shared-types";
 import { apiFetch } from "./client";
 
 export function listTeams(): Promise<TeamResponse[]> {
@@ -36,4 +36,8 @@ export function addTeamMember(teamId: string, body: AddMemberRequest): Promise<T
 
 export function getTeamAnalyticsSummary(teamId: string): Promise<TeamAnalyticsSummary> {
   return apiFetch<TeamAnalyticsSummary>(`/v0/teams/${teamId}/analytics/summary`);
+}
+
+export function getTeamInsights(teamId: string): Promise<TeamInsights> {
+  return apiFetch<TeamInsights>(`/v0/teams/${teamId}/analytics/insights`);
 }

--- a/apps/web/src/test/team-insights.test.tsx
+++ b/apps/web/src/test/team-insights.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * apps/web/src/test/team-insights.test.tsx
+ * Tests for TeamInsightsPanel: loading, data, empty, and error states.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+import * as teamsApi from "@/lib/api/teams";
+import { TeamInsightsPanel } from "@/components/teams/TeamInsightsPanel";
+import { ApiError } from "@/lib/api/client";
+import type { TeamInsights } from "@debugiq/shared-types";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const MOCK_INSIGHTS: TeamInsights = {
+  daily_results_last_14d: [
+    { date: "2026-03-23", count: 0 },
+    { date: "2026-03-24", count: 1 },
+    { date: "2026-03-25", count: 0 },
+    { date: "2026-03-26", count: 2 },
+    { date: "2026-03-27", count: 0 },
+    { date: "2026-03-28", count: 0 },
+    { date: "2026-03-29", count: 0 },
+    { date: "2026-03-30", count: 1 },
+    { date: "2026-03-31", count: 0 },
+    { date: "2026-04-01", count: 3 },
+    { date: "2026-04-02", count: 0 },
+    { date: "2026-04-03", count: 1 },
+    { date: "2026-04-04", count: 0 },
+    { date: "2026-04-05", count: 2 },
+  ],
+  top_bug_categories_last_30d: [
+    { category: "sql_injection", count: 5 },
+    { category: "xss", count: 3 },
+  ],
+  top_signatures_last_30d: [
+    { signature_hash: "abc123def456789012345678", count: 4 },
+    { signature_hash: "xyz789abc123456789012345", count: 2 },
+  ],
+  member_activity_last_30d: [
+    { user_id: "user-uuid-1", display_name: "Alice", results_count: 8 },
+    { user_id: "user-uuid-2", display_name: null, results_count: 3 },
+  ],
+};
+
+const EMPTY_INSIGHTS: TeamInsights = {
+  daily_results_last_14d: Array.from({ length: 14 }, (_, i) => ({
+    date: `2026-03-${String(i + 1).padStart(2, "0")}`,
+    count: 0,
+  })),
+  top_bug_categories_last_30d: [],
+  top_signatures_last_30d: [],
+  member_activity_last_30d: [],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("TeamInsightsPanel — loading", () => {
+  it("renders the loading indicator while the request is in-flight", () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockReturnValue(
+      new Promise(() => {}), // never resolves
+    );
+    render(<TeamInsightsPanel teamId="team-abc" />);
+    expect(screen.getByTestId("insights-loading")).toBeTruthy();
+  });
+});
+
+describe("TeamInsightsPanel — success", () => {
+  it("renders the insights panel", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockResolvedValue(MOCK_INSIGHTS);
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("insights-panel")).toBeTruthy();
+  });
+
+  it("renders the trend bars when there is activity", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockResolvedValue(MOCK_INSIGHTS);
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("trend-bars")).toBeTruthy();
+  });
+
+  it("displays category labels and member names", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockResolvedValue(MOCK_INSIGHTS);
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    // Category with underscores rendered as spaces
+    expect(screen.getByText("sql injection")).toBeTruthy();
+    expect(screen.getByText("xss")).toBeTruthy();
+
+    // Member with display_name shows name; null falls back to user_id prefix
+    expect(screen.getByText("Alice")).toBeTruthy();
+    // user-uuid-2 has no display_name → shows "user-uui…" (first 8 chars)
+    expect(screen.getByText("user-uui…")).toBeTruthy();
+  });
+});
+
+describe("TeamInsightsPanel — empty state", () => {
+  it("renders empty-state messages when all lists are empty", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockResolvedValue(EMPTY_INSIGHTS);
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByText("No activity in the last 14 days.")).toBeTruthy();
+    expect(screen.getByText("No findings recorded yet.")).toBeTruthy();
+    expect(screen.getByText("No signatures recorded yet.")).toBeTruthy();
+    expect(screen.getByText("No member activity in the last 30 days.")).toBeTruthy();
+  });
+});
+
+describe("TeamInsightsPanel — error", () => {
+  it("renders the error state when the request fails with ApiError", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockRejectedValue(
+      new ApiError(403, "not_a_member"),
+    );
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("insights-error")).toBeTruthy();
+    expect(screen.getByText("not_a_member")).toBeTruthy();
+  });
+
+  it("shows generic message for unknown errors", async () => {
+    vi.spyOn(teamsApi, "getTeamInsights").mockRejectedValue(
+      new Error("network failure"),
+    );
+
+    await act(async () => {
+      render(<TeamInsightsPanel teamId="team-abc" />);
+    });
+
+    expect(screen.getByTestId("insights-error")).toBeTruthy();
+    expect(screen.getByText("Failed to load team insights.")).toBeTruthy();
+  });
+});

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -160,3 +160,33 @@ export interface TeamAnalyticsSummary {
   language_counts: LanguageCounts;
   active_members_last_30d: number;
 }
+
+// ── Team Insights API Shapes ──────────────────────────────────────────────────
+
+export interface DailyResultCount {
+  date: string;  // ISO date YYYY-MM-DD
+  count: number;
+}
+
+export interface CategoryCount {
+  category: string;
+  count: number;
+}
+
+export interface SignatureCount {
+  signature_hash: string;
+  count: number;
+}
+
+export interface MemberActivityEntry {
+  user_id: string;
+  display_name: string | null;
+  results_count: number;
+}
+
+export interface TeamInsights {
+  daily_results_last_14d: DailyResultCount[];
+  top_bug_categories_last_30d: CategoryCount[];
+  top_signatures_last_30d: SignatureCount[];
+  member_activity_last_30d: MemberActivityEntry[];
+}


### PR DESCRIPTION
Summary
This PR delivers Team Insights v2 on top of the existing team analytics foundation.

It adds:

A new backend insights endpoint for team-scoped trend/ranking data
Shared API types for the new contract
A web Team Insights panel rendered in team scope
API + web tests covering success, errors, and empty states
What Was Changed
API
Added new endpoint:
GET /v0/teams/{team_id}/analytics/insights
Added typed response schemas in [router.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
[DailyResultCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[CategoryCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[SignatureCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[MemberActivityEntry](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[TeamInsights](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Member authorization is enforced (team membership required)
Minor typing hardening:
[set[Any]](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> [set[uuid.UUID]](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in summary endpoint internals
Shared Types
Added interfaces in [api.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) matching backend response shape:

[DailyResultCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[CategoryCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[SignatureCount](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[MemberActivityEntry](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[TeamInsights](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Web
Added API wrapper:
getTeamInsights(teamId) in [teams.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added new UI component:
[TeamInsightsPanel.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Wired dashboard rendering:
[page.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
TeamInsightsPanel appears when team scope is active (below TeamAnalyticsPanel)
API Contract
GET /v0/teams/{team_id}/analytics/insights returns:
{
  "daily_results_last_14d": [{ "date": "YYYY-MM-DD", "count": 3 }],
  "top_bug_categories_last_30d": [{ "category": "sql_injection", "count": 5 }],
  "top_signatures_last_30d": [{ "signature_hash": "abc123...", "count": 4 }],
  "member_activity_last_30d": [{ "user_id": "...", "display_name": "Alice", "results_count": 8 }]
}
UI Behavior
In team scope, TeamInsightsPanel shows:

14-day activity mini bar chart (CSS-based)
Top bug categories list
Top signatures list (12-char hash prefix)
Ranked member activity list
Handled states:

loading
data
error
empty list fallback for each section
Validation
All checks pass locally:

ruff check ✅
mypy src ✅ (21 source files)
pytest ✅ (57 passed)
pnpm lint ✅
pnpm typecheck ✅
pnpm test ✅ (30 passed, 6 files)
pnpm --filter @debugiq/shared-types typecheck ✅
Deferred (Intentional)
Configurable top-N via query param (currently fixed at 10)
Flexible date ranges via query params (beyond 14d/30d defaults)
Heavier charting library (current MVP uses proportional CSS bars)
Commit
9dec492 — feat(teams): add team insights endpoint and dashboard insights panel